### PR TITLE
Fixed GitHub links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ and want to see those settings live as you edit them.
 ## Links
 
 - [Flarum Discuss post](https://discuss.flarum.org/d/10395-zaptech-cookie-consent)
-- [Source code on GitHub](https://github.com/partialdev/cookie-consent)
-- [Report an issue](https://github.com/partialdev/cookie-consent/issues)
+- [Source code on GitHub](https://github.com/partialdev/zaptech-cookie-consent)
+- [Report an issue](https://github.com/partialdev/zaptech-cookie-consent/issues)
 - [Download via Packagist](https://packagist.org/packages/zaptech/cookie-consent)
 
 An extension by [PartialDev](https://partialdev.com).


### PR DESCRIPTION
I'm not sure if the project was renamed to zaptech-cookie-consent but I seemed to have missed that in the README GitHub links. You may want to update your Flarum discussion post as well with the correct GitHub links.

Meanwhile, this fix can be added to the next release when a new feature or bugfix is needed.